### PR TITLE
add missing installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ Blockchain-specific code for the Sidetree-based DID Method implementation on Bit
 
 Our reference implementation of the blockchain service is based on bitcored. Here is the list of instructions to deploy Sidetree's blockchain service on your node.
 
-- Install a Bitcored full node using instructions at [this link](https://bitcore.io/guides/full-node). We reproduce their instructions below since we run bitcored with node v9 rather than v4:
+- Install a Bitcored full node using instructions at [this link](https://github.com/bitpay/bitcore#bitcore). We reproduce their instructions below since we run bitcored with node v9 rather than v4:
 
   - Install node version manager (NVM) by following instructions at [this link](https://github.com/creationix/nvm#install-script).
   - Install node v9 by using: 
      ```bash 
      nvm install v9
      ```
-  - Install ZeroMQ and Tools. On GNU/Debian distributions, do:
+  - Install Python, ZeroMQ, and Tools. On GNU/Debian distributions, do:
     ```bash
-    apt-get install libzmq3-dev build-essential
+    apt-get install python libzmq3-dev build-essential
     ```
   - Install bitcore:
     ```bash
@@ -31,6 +31,13 @@ Our reference implementation of the blockchain service is based on bitcored. Her
       cd $(SIDETREE_BITCOIN_REPO)/src/bitcored-services/sidetree
       npm install bitcore-lib
     ```
+
+- Install insight UI:
+  ```bash
+  cd $(BITCORE_DIR)
+  bitcore install insight-api insight-ui
+  ```
+
 - Suppose that we install bitcored to `$(BITCORE_DIR)` on `$(NODE_IP)`, use the following instructions to add Sidetree's blockchain service:
 
    ```bash
@@ -38,11 +45,6 @@ Our reference implementation of the blockchain service is based on bitcored. Her
       ln -s $(SIDETREE_BITCOIN_REPO)/src/bitcored-services/sidetree
       add the string "sidetree" to the services array in $BITCORE_DIR/bitcore-node.json
     ```
-
-- Install insight UI:
-  ```bash
-  bitcore install insight-api insight-ui
-  ```
 
 - Start the `bitcored` daemon by running:
 


### PR DESCRIPTION
Fix broken link to bitcore install guide.
Also looks like python is a dependency for bitcore.
Finally, I moved the insight install before the creation of the symbolic link because I believe the install deleted the symbolic link on my machine; I had to recreate it after installing insight.